### PR TITLE
Recursive type inference

### DIFF
--- a/backend/DynamicRuntime.cpp
+++ b/backend/DynamicRuntime.cpp
@@ -102,7 +102,7 @@ extern "C" {
       return NULL;
     }
    
-    struct InvokationCache *entry = NULL;
+    struct InvokationCache *entry = NULL, *cachePosition = NULL;
     for(int i=0; i<INVOKATION_CACHE_SIZE; i++) { 
       /* Fast cache access */
       entry = &(method->invokations[i]);
@@ -111,7 +111,7 @@ extern "C" {
          entry->signature[2] == argSignature[2] && 
          entry->packed == packedArg &&
          entry->returnType == retValType) return entry->fptr;
-      if(entry->signature[0] != 0) entry = NULL;
+      if(entry->signature[0] == 0) cachePosition = entry;
     } 
 
     std::vector<ObjectTypeSet> argT;
@@ -151,13 +151,13 @@ extern "C" {
     auto ExprSymbol = eo(jit->lookup(rqName));
     void *retVal = (void *)ExprSymbol.getAddress();
       
-    if(entry) { /* Store in cache if free entries available */
-      entry->signature[0] = argSignature[0];
-      entry->signature[1] = argSignature[1];
-      entry->signature[2] = argSignature[2];
-      entry->packed = packedArg;
-      entry->returnType = retValType;
-      entry->fptr = retVal;
+    if(cachePosition) { /* Store in cache if free entries available */
+      cachePosition->signature[0] = argSignature[0];
+      cachePosition->signature[1] = argSignature[1];
+      cachePosition->signature[2] = argSignature[2];
+      cachePosition->packed = packedArg;
+      cachePosition->returnType = retValType;
+      cachePosition->fptr = retVal;
     }
 
     return retVal;

--- a/backend/Exceptions.h
+++ b/backend/Exceptions.h
@@ -19,10 +19,4 @@ class InternalInconsistencyException: public std::exception {
   std::string toString() const { return errorMessage; } 
 };
 
-class UnaccountedRecursiveFunctionEncounteredException: public std::exception {
-  public:
-  std::string functionName;
-  UnaccountedRecursiveFunctionEncounteredException(const std::string &functionName): functionName(functionName) { }
-};
-
 #endif

--- a/backend/ObjectTypeSet.h
+++ b/backend/ObjectTypeSet.h
@@ -320,7 +320,7 @@ class ObjectTypeSet {
     /* Expansion removes all constants */
     auto retVal = ObjectTypeSet(*this);
     retVal.internal.insert(other.internal.begin(), other.internal.end());
-    retVal.isBoxed = isBoxed || other.isBoxed || retVal.size() > 1;
+    retVal.isBoxed = (isBoxed && !isEmpty()) || (other.isBoxed && !other.isEmpty()) || retVal.size() > 1;
     if(retVal.constant) delete retVal.constant;
     retVal.constant = nullptr;
     return retVal;

--- a/backend/Programme.h
+++ b/backend/Programme.h
@@ -50,6 +50,7 @@ class ProgrammeState {
   std::unordered_map<std::string, uint64_t> RecurTargets;
   std::unordered_map<std::string, uint64_t> StaticFunctions;
   std::unordered_map<std::string, ObjectTypeSet> RecursiveFunctionsRetValGuesses;
+  std::unordered_map<std::string, ObjectTypeSet> FunctionsRetValInfers;
   std::unordered_map<std::string, bool> RecursiveFunctionsNameMap;
   std::unordered_map<std::string, std::vector<std::pair<std::string, std::pair<StaticCallType, StaticCall>>>> StaticCallLibrary;
   std::unordered_map<std::string, ObjectTypeSet> StaticVarTypes;

--- a/backend/codegen.h
+++ b/backend/codegen.h
@@ -94,7 +94,8 @@ TypedValue callStaticFun(const Node &node, const FnNode& body, const std::pair<F
 
   llvm::Value *callDynamicFun(const Node &node, llvm::Value *rtFnPointer, const ObjectTypeSet &retValType, const std::vector<TypedValue> &args);
   llvm::Value *dynamicInvoke(const Node &node, llvm::Value *objectToInvoke, llvm::Value* objectType, const ObjectTypeSet &retValType, const std::vector<TypedValue> &args, llvm::Value *uniqueFunctionId = nullptr, llvm::Function *staticFunctionToCall = nullptr);    
-ObjectTypeSet determineMethodReturn(const FnMethodNode &method, const uint64_t uniqueId, const std::vector<ObjectTypeSet> &args, const std::vector<ObjectTypeSet> &closedOvers, const ObjectTypeSet &typeRestrictions);
+  ObjectTypeSet determineMethodReturn(const FnMethodNode &method, const uint64_t uniqueId, const std::vector<ObjectTypeSet> &args, const std::vector<ObjectTypeSet> &closedOvers, const ObjectTypeSet &typeRestrictions);
+  ObjectTypeSet inferMethodReturn(const FnMethodNode &method, const uint64_t uniqueId, const std::vector<ObjectTypeSet> &args, const std::vector<ObjectTypeSet> &closedOvers, const ObjectTypeSet &typeRestrictions);
 
   /* Runtime types */
 

--- a/tests/arith-benchmark.clj
+++ b/tests/arith-benchmark.clj
@@ -1,23 +1,3 @@
-;; (defn branch [n x y]
-;;   (if (= n 0)
-;;     (+ x y)
-;;     (let [v0 (branch (- n 1) x y)
-;;           v1 (branch (- n 1) v0 y)
-;;           v2 (branch (- n 1) v1 y)
-;;           v3 (branch (- n 1) v2 y)
-;;           v4 (branch (- n 1) v3 y)
-;;           v5 (branch (- n 1) v4 y)
-;;           v6 (branch (- n 1) v5 y)
-;;           v7 (branch (- n 1) v6 y)
-;;           v8 (branch (- n 1) v7 y)
-;;           v9 (branch (- n 1) v8 y)]
-;;       v9)))
-
-;; ;; Clojre execution time ~2,5s
-;; ;; Our compiler compiles for 7 seconds can't generate module even if n = 0!
-;; (branch 8 0N 2N)
-
-;; LLVM error
 (defn stick [n x y]
   (if (= n 0)
     (+ x y)
@@ -25,4 +5,57 @@
           v1 (stick (- n 1) v0 y)]
       v1)))
 
-(stick 0 0N 2N)
+(stick 25 0N 1N)
+
+(stick 25 0 1)
+
+
+(defn stick2 [n y]
+  (if (= n 0)
+    y
+    (let [v0 (stick2 (- n 1) y)
+          v1 (stick2 (- n 1) y)]
+      (+ v0 v1))))
+
+(stick2 25 1N)
+
+(stick2 25 1)
+
+
+(defn fib-acc
+  [n x y]
+  (if (= n 0)
+    x
+    (if (= n 100)
+      12345678890N
+      (fib-acc (- n 1) y (+ x y)))))
+
+(+ (fib-acc 42 0N 1N) 3N)
+(fib-acc 142 0N 1N)
+
+
+(defn fib-acc-2
+  [n x y]
+  (if (= n 0)
+    x
+    (if (= n 100)
+      "kuku"
+      (fib-acc-2 (- n 1) y (+ x y)))))
+
+(+ (fib-acc-2 42 0N 1N) 3N)
+(fib-acc-2 142 0N 1N)
+
+(defn noop
+  [n]
+  (if (= n 0)
+    (let [v0 (* 1234567890N 1234567890N)
+          v1 (* 1234567890N v0)
+          v2 (* 1234567890N v1)
+          v3 (* 1234567890N v2)
+          v4 (* 1234567890N v3)]
+      0)
+    (do (noop (- n 1))
+        (noop (- n 1)))))
+
+(noop 25)
+


### PR DESCRIPTION
Uwaga, PR jest od rational numbers, a nie od mastera

Przykład, z którym walczę:

```
(defn stick [n x y]
  (if (= n 0)
    (+ x y)
    (let [v0 (stick (- n 1) x y)
          v1 (stick (- n 1) v0 y)]
      v1)))

;; in pure Clojure: <1s
;; in our compiler, with BigInteger reuse: <7s
;; in our compiler, without BigInteger reuse: <14s
(stick 25 0N 1N)

;; in pure Clojure: <1s
;; in our compiler: <9s
(stick 25 0 1)
```

Jeśli zakomentujesz jedno z wywołań `stick`, kompilator generuje dobry kod. Jeśli jednak odpalisz oba, czas wykonania absurdalnie rośnie:
* tylko `(stick 15 0N 1N)` 6ms
* tylko `(stick 15 0 1)` 35ms (przez LJ)
* obie formy: druga ma czas wykonania 1.5s