### PR TITLE
RetainRelease pass

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
      main.cpp 
      codegen.cpp 
      jit/jit.cpp 
+     llvm-passes/RetainRelease.cpp
      ops/BindingNode.cpp 
      ops/CaseNode.cpp 
      ops/CaseTestNode.cpp 

--- a/backend/jit/jit.cpp
+++ b/backend/jit/jit.cpp
@@ -1,5 +1,6 @@
 #include "jit.h"
 #include <iostream>
+#include "llvm-passes/RetainRelease.h"
 
 using namespace std;
 using namespace llvm::orc;
@@ -99,6 +100,8 @@ Expected<ThreadSafeModule> ClojureJIT::optimiseModule(ThreadSafeModule TSM, cons
 
     // The vetification pass is much stronger than just "verify" on the module 
     TheFPM->add(createVerifierPass());    
+    
+    TheFPM->add(createRetainReleasePass());
 
     // Add some optimizations.
     TheFPM->add(llvm::createPromoteMemoryToRegisterPass());

--- a/backend/llvm-passes/RetainRelease.cpp
+++ b/backend/llvm-passes/RetainRelease.cpp
@@ -1,0 +1,88 @@
+#include "llvm/Pass.h"
+#include "llvm/IR/Argument.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "RetainRelease.h"
+#include <unordered_map>
+
+using namespace std;
+using namespace llvm;
+
+char RetainReleasePass::ID = 0;
+
+FunctionPass *createRetainReleasePass() {
+  return new RetainReleasePass();
+};
+
+bool RetainReleasePass::runOnFunction(Function &F) {
+  bool isChanged = false;
+  auto blockIt = F.begin();
+  while (blockIt != F.end()) {
+    unordered_map<Value *, vector<Instruction *>> retains;
+    auto instrIt = blockIt->begin();
+    while (instrIt != blockIt->end()) {
+      if (MDNode* MDNode = instrIt->getMetadata("memory_management")) { // retain or release instruction
+        StringRef mmType = dyn_cast<MDString>(MDNode->operands()[0])->getString();
+        if (mmType.equals("retain")) {
+          if (CallBase* call = dyn_cast<CallBase>(instrIt)) {
+            assert(call->getCalledFunction()->getName().equals("retain"));
+            auto arg = call->arg_begin();
+            assert(arg != call->arg_end());
+            if (Value* val = dyn_cast<Value>(arg)) {
+              auto instructions = retains.find(val);
+              // instrIt->print(errs());
+              if (instructions == retains.end()) {
+                retains.insert({val, {&(*instrIt)}});
+              } else {
+                instructions->second.push_back(&(*instrIt));
+              }
+            }
+          }
+          ++instrIt;
+        } else if (mmType.equals("release")) {
+          if (CallBase* call = dyn_cast<CallBase>(instrIt)) {
+            assert(call->getCalledFunction()->getName().equals("release"));
+            auto arg = call->arg_begin();
+            assert(arg != call->arg_end());
+            if (Value* val = dyn_cast<Value>(arg)) {
+              auto instructions = retains.find(val);
+              // instrIt->print(errs());
+              if (instructions != retains.end()) {
+                auto retains = &instructions->second;
+                if (!retains->empty()) {
+                  Instruction* lastRelease = retains->back();
+                  retains->pop_back();
+                  lastRelease->eraseFromParent();
+                  instrIt = instrIt->eraseFromParent();
+                } else {
+                  ++instrIt;
+                }
+              } else {
+                ++instrIt;
+              }
+            } else {
+              ++instrIt;
+            }
+          } else {
+            ++instrIt;
+          }
+        } else {
+          ++instrIt;
+        }
+      } else { // any other instruction
+        if (User* user = dyn_cast<User>(instrIt)) {
+          for (auto val = user->value_op_begin(); val != user->value_op_end(); ++val) {
+            auto valRetains = retains.find(*val);
+            if (valRetains != retains.end() && !valRetains->second.empty()) {
+              isChanged = true;
+              valRetains->second.pop_back();
+            }
+          }
+        }
+        ++instrIt;
+      }
+    }
+    ++blockIt;
+  }
+  return isChanged;
+}

--- a/backend/llvm-passes/RetainRelease.cpp
+++ b/backend/llvm-passes/RetainRelease.cpp
@@ -53,24 +53,6 @@ bool RetainReleasePass::runOnFunction(Function &F) {
             auto arg = call->arg_begin();
             assert(arg != call->arg_end());
             val = dyn_cast<Value>(arg);
-            if (val) {
-              auto instructions = retains.find(val);
-              if (instructions != retains.end()) {
-                auto retains = &instructions->second;
-                if (!retains->empty()) {
-                  Instruction* lastRelease = retains->back();
-                  retains->pop_back();
-                  lastRelease->eraseFromParent();
-                  instrIt = instrIt->eraseFromParent();
-                } else {
-                  ++instrIt;
-                }
-              } else {
-                ++instrIt;
-              }
-            } else {
-              ++instrIt;
-            }
           } else if (dec) {
             val = dec->getPointerOperand();
           }

--- a/backend/llvm-passes/RetainRelease.cpp
+++ b/backend/llvm-passes/RetainRelease.cpp
@@ -17,36 +17,44 @@ FunctionPass *createRetainReleasePass() {
 bool RetainReleasePass::runOnFunction(Function &F) {
   bool isChanged = false;
   auto blockIt = F.begin();
+  // errs() << "---> Function body:\n" << F << "\n";
   while (blockIt != F.end()) {
+    // errs() << "---> Basic block:\n" << *blockIt << "\n";
     unordered_map<Value *, vector<Instruction *>> retains;
     auto instrIt = blockIt->begin();
     while (instrIt != blockIt->end()) {
+      // errs() << "---> Instruction:\n" << *instrIt << "\n";
       if (MDNode* MDNode = instrIt->getMetadata("memory_management")) { // retain or release instruction
+        Value* val = nullptr;
         StringRef mmType = dyn_cast<MDString>(MDNode->operands()[0])->getString();
         if (mmType.equals("retain")) {
           if (CallBase* call = dyn_cast<CallBase>(instrIt)) {
             assert(call->getCalledFunction()->getName().equals("retain"));
             auto arg = call->arg_begin();
             assert(arg != call->arg_end());
-            if (Value* val = dyn_cast<Value>(arg)) {
-              auto instructions = retains.find(val);
-              // instrIt->print(errs());
-              if (instructions == retains.end()) {
-                retains.insert({val, {&(*instrIt)}});
-              } else {
-                instructions->second.push_back(&(*instrIt));
-              }
+            val = dyn_cast<Value>(arg);
+          } else if (AtomicRMWInst* inc = dyn_cast<AtomicRMWInst>(instrIt)) {
+            val = inc->getPointerOperand();
+          }
+          if (val) {
+            auto instructions = retains.find(val);
+            if (instructions == retains.end()) {
+              retains.insert({val, {&(*instrIt)}});
+            } else {
+              instructions->second.push_back(&(*instrIt));
             }
           }
           ++instrIt;
         } else if (mmType.equals("release")) {
-          if (CallBase* call = dyn_cast<CallBase>(instrIt)) {
+          CallBase* call = dyn_cast<CallBase>(instrIt);
+          AtomicRMWInst* dec = dyn_cast<AtomicRMWInst>(instrIt);
+          if (call) {
             assert(call->getCalledFunction()->getName().equals("release"));
             auto arg = call->arg_begin();
             assert(arg != call->arg_end());
-            if (Value* val = dyn_cast<Value>(arg)) {
+            val = dyn_cast<Value>(arg);
+            if (val) {
               auto instructions = retains.find(val);
-              // instrIt->print(errs());
               if (instructions != retains.end()) {
                 auto retains = &instructions->second;
                 if (!retains->empty()) {
@@ -63,6 +71,65 @@ bool RetainReleasePass::runOnFunction(Function &F) {
             } else {
               ++instrIt;
             }
+          } else if (dec) {
+            val = dec->getPointerOperand();
+          }
+          if (val) {
+            auto instructions = retains.find(val);
+            if (instructions != retains.end()) {
+              auto retains = &instructions->second;
+                if (!retains->empty()) {
+                  Instruction* lastRelease = retains->back();
+                  retains->pop_back();
+                  lastRelease->eraseFromParent();
+                  isChanged = true;
+                  if (call) {
+                    instrIt = instrIt->eraseFromParent(); // call release
+                  } else if (dec) {
+                    // current_block:
+                    //   ...
+                    //   %0 = atomicrmw volatile sub ... <- instrIt
+                    //   %cmp_jj = icmp eq i64 %0, 1
+                    //   br i1 %cmp_jj, label %destroy, label %ignore
+                    //
+                    // destroy:
+                    //   tail call void @Object_destroy ...
+                    //   label %release_cont
+                    //
+                    // ignore:
+                    //   label %release_cont
+                    //
+                    // release_cont:
+                    //   %release_phi = phi i1 [ true, %destroy ], [ false, %ignore ] <- dummy value, not used
+                    //   No other phi instructions!
+                    // Delete remaining instructions in current block, starting from instrIt
+                    // Delete destroy and ignore blocks
+                    // Merge current_block (with deleted instructions) and release_cont (without release_phi)
+                    
+                    instrIt = instrIt->eraseFromParent(); // sub
+                    assert(instrIt != blockIt->end() && "Expected icmp instruction, got end of block instead!");
+                    instrIt = instrIt->eraseFromParent(); // icmp
+                    assert(instrIt != blockIt->end() && "Expected br instruction, got end of block instead!");
+                    BranchInst* br = dyn_cast<BranchInst>(instrIt);
+                    assert(br && br->getNumSuccessors() == 2);
+                    BasicBlock *destroy = br->getSuccessor(0),
+                               *ignore = br->getSuccessor(1),
+                               *cont = dyn_cast<BranchInst>(ignore->begin())->getSuccessor(0);
+                    destroy->eraseFromParent();
+                    ignore->eraseFromParent();
+                    instrIt = instrIt->eraseFromParent(); // br
+                    assert(instrIt == blockIt->end() && "Br wasn't the last instruction in block!");
+                    auto contIt = cont->getFirstNonPHIOrDbgOrAlloca();
+                    blockIt->splice(blockIt->end(), cont);
+                    cont->eraseFromParent();
+                    instrIt = contIt;
+                  }
+                } else {
+                  ++instrIt;
+                }
+            } else {
+              ++instrIt;
+            }
           } else {
             ++instrIt;
           }
@@ -74,7 +141,6 @@ bool RetainReleasePass::runOnFunction(Function &F) {
           for (auto val = user->value_op_begin(); val != user->value_op_end(); ++val) {
             auto valRetains = retains.find(*val);
             if (valRetains != retains.end() && !valRetains->second.empty()) {
-              isChanged = true;
               valRetains->second.pop_back();
             }
           }

--- a/backend/llvm-passes/RetainRelease.cpp
+++ b/backend/llvm-passes/RetainRelease.cpp
@@ -1,4 +1,5 @@
 #include "llvm/Pass.h"
+#include "llvm/ADT/simple_ilist.h"
 #include "llvm/IR/Argument.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"
@@ -13,6 +14,18 @@ char RetainReleasePass::ID = 0;
 FunctionPass *createRetainReleasePass() {
   return new RetainReleasePass();
 };
+
+// void disf(Function* x) {
+//   errs() << "---> Function body:\n" << *x << "\n";
+// }
+
+// void disb(BasicBlock* x) {
+//   errs() << "---> Basic block:\n" << *x << "\n";
+// }
+
+// void disi(Instruction* x) {
+//   errs() << "---> Instruction:\n" << *x << "\n";
+// }
 
 bool RetainReleasePass::runOnFunction(Function &F) {
   bool isChanged = false;
@@ -60,55 +73,54 @@ bool RetainReleasePass::runOnFunction(Function &F) {
             auto instructions = retains.find(val);
             if (instructions != retains.end()) {
               auto retains = &instructions->second;
-                if (!retains->empty()) {
-                  Instruction* lastRelease = retains->back();
-                  retains->pop_back();
-                  lastRelease->eraseFromParent();
-                  isChanged = true;
-                  if (call) {
-                    instrIt = instrIt->eraseFromParent(); // call release
-                  } else if (dec) {
-                    // current_block:
-                    //   ...
-                    //   %0 = atomicrmw volatile sub ... <- instrIt
-                    //   %cmp_jj = icmp eq i64 %0, 1
-                    //   br i1 %cmp_jj, label %destroy, label %ignore
-                    //
-                    // destroy:
-                    //   tail call void @Object_destroy ...
-                    //   label %release_cont
-                    //
-                    // ignore:
-                    //   label %release_cont
-                    //
-                    // release_cont:
-                    //   %release_phi = phi i1 [ true, %destroy ], [ false, %ignore ] <- dummy value, not used
-                    //   No other phi instructions!
-                    // Delete remaining instructions in current block, starting from instrIt
-                    // Delete destroy and ignore blocks
-                    // Merge current_block (with deleted instructions) and release_cont (without release_phi)
-                    
-                    instrIt = instrIt->eraseFromParent(); // sub
-                    assert(instrIt != blockIt->end() && "Expected icmp instruction, got end of block instead!");
-                    instrIt = instrIt->eraseFromParent(); // icmp
-                    assert(instrIt != blockIt->end() && "Expected br instruction, got end of block instead!");
-                    BranchInst* br = dyn_cast<BranchInst>(instrIt);
-                    assert(br && br->getNumSuccessors() == 2);
-                    BasicBlock *destroy = br->getSuccessor(0),
-                               *ignore = br->getSuccessor(1),
-                               *cont = dyn_cast<BranchInst>(ignore->begin())->getSuccessor(0);
-                    destroy->eraseFromParent();
-                    ignore->eraseFromParent();
-                    instrIt = instrIt->eraseFromParent(); // br
-                    assert(instrIt == blockIt->end() && "Br wasn't the last instruction in block!");
-                    auto contIt = cont->getFirstNonPHIOrDbgOrAlloca();
-                    blockIt->splice(blockIt->end(), cont);
-                    cont->eraseFromParent();
-                    instrIt = contIt;
-                  }
-                } else {
-                  ++instrIt;
+              if (!retains->empty()) {
+                Instruction* lastRelease = retains->back();
+                retains->pop_back();
+                lastRelease->eraseFromParent();
+                isChanged = true;
+                if (call) {
+                  instrIt = instrIt->eraseFromParent(); // call release
+                } else if (dec) {
+                  // current_block:
+                  //   ...
+                  //   %0 = atomicrmw volatile sub ... <- instrIt
+                  //   %cmp_jj = icmp eq i64 %0, 1
+                  //   br i1 %cmp_jj, label %destroy, label %ignore
+                  //
+                  // destroy:
+                  //   tail call void @Object_destroy ...
+                  //   label %release_cont
+                  //
+                  // ignore:
+                  //   label %release_cont
+                  //
+                  // release_cont:
+                  //   %release_phi = phi i1 [ true, %destroy ], [ false, %ignore ] <- dummy value, not used
+                  //   No other phi instructions!
+                  // Delete remaining instructions in current block, starting from instrIt
+                  // Delete destroy and ignore blocks
+                  // Merge current_block (with deleted instructions) and release_cont (without release_phi)
+                  
+                  instrIt = instrIt->eraseFromParent(); // sub
+                  assert(instrIt != blockIt->end() && "Expected icmp instruction, got end of block instead!");
+                  instrIt = instrIt->eraseFromParent(); // icmp
+                  assert(instrIt != blockIt->end() && "Expected br instruction, got end of block instead!");
+                  BranchInst* br = dyn_cast<BranchInst>(instrIt);
+                  assert(br && br->getNumSuccessors() == 2);
+                  BasicBlock *destroy = br->getSuccessor(0),
+                              *ignore = br->getSuccessor(1),
+                              *cont = dyn_cast<BranchInst>(ignore->begin())->getSuccessor(0);
+                  auto contIt = cont->getFirstNonPHIOrDbgOrAlloca();
+                  blockIt->splice(blockIt->end(), cont, contIt, cont->end());
+                  instrIt->eraseFromParent();
+                  destroy->eraseFromParent();
+                  ignore->eraseFromParent();
+                  cont->eraseFromParent();
+                  instrIt = contIt;
                 }
+              } else {
+                ++instrIt;
+              }
             } else {
               ++instrIt;
             }

--- a/backend/llvm-passes/RetainRelease.cpp
+++ b/backend/llvm-passes/RetainRelease.cpp
@@ -57,7 +57,6 @@ bool RetainReleasePass::runOnFunction(Function &F) {
               instructions->second.push_back(&(*instrIt));
             }
           }
-          ++instrIt;
         } else if (mmType.equals("release")) {
           CallBase* call = dyn_cast<CallBase>(instrIt);
           AtomicRMWInst* dec = dyn_cast<AtomicRMWInst>(instrIt);
@@ -80,7 +79,7 @@ bool RetainReleasePass::runOnFunction(Function &F) {
                 isChanged = true;
                 if (call) {
                   instrIt = instrIt->eraseFromParent(); // call release
-                } else if (dec) {
+                } else { // dec
                   // current_block:
                   //   ...
                   //   %0 = atomicrmw volatile sub ... <- instrIt
@@ -118,17 +117,10 @@ bool RetainReleasePass::runOnFunction(Function &F) {
                   cont->eraseFromParent();
                   instrIt = contIt;
                 }
-              } else {
-                ++instrIt;
+                continue; // skip ++instrIt, it was manually updated
               }
-            } else {
-              ++instrIt;
             }
-          } else {
-            ++instrIt;
           }
-        } else {
-          ++instrIt;
         }
       } else { // any other instruction
         if (User* user = dyn_cast<User>(instrIt)) {
@@ -139,8 +131,8 @@ bool RetainReleasePass::runOnFunction(Function &F) {
             }
           }
         }
-        ++instrIt;
       }
+      ++instrIt;
     }
     ++blockIt;
   }

--- a/backend/llvm-passes/RetainRelease.h
+++ b/backend/llvm-passes/RetainRelease.h
@@ -1,0 +1,21 @@
+#ifndef LLVM_PASSES_RETAINRELEASE
+#define LLVM_PASSES_RETAINRELEASE
+
+#include "llvm/Pass.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/LegacyPassManager.h"
+
+using namespace llvm;
+
+class RetainReleasePass : public FunctionPass {
+  public:
+  
+  static char ID;
+  
+  explicit RetainReleasePass() : FunctionPass(ID) {};
+  bool runOnFunction(Function &F) override;
+};
+
+FunctionPass *createRetainReleasePass();
+
+#endif


### PR DESCRIPTION
```
(defn f []
  (let [x 1N
        y (+ x 2N)
        z (+ y 3N)]
    (+ z 4N)))

(f)
```
już nie tworzy nadmiarowych release/retain na wartości tymczasowe, tylko
```
define ptr @fn_1__LI(ptr %0) {
entry:
  tail call void @retain(ptr nonnull inttoptr (i64 140191791737376 to ptr)), !memory_management !0
  tail call void @release(ptr %0), !memory_management !1
  ret ptr inttoptr (i64 140191791737376 to ptr)
}
```

*WIP!* Do zrobienia w wersji inline